### PR TITLE
Some improvements

### DIFF
--- a/nimrun
+++ b/nimrun
@@ -20,12 +20,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+# First try compilers which are known to be fast(er than GCC)
+if command -v tcc >/dev/null 2>&1; then
+  COMPILER=--cc:tcc
+elif command -v clang >/dev/null 2>&1; then
+  COMPILER=--cc:clang
+fi
 
 output=$(mktemp -d)
 trap "rm -rf $output" EXIT
 
 nim c --verbosity:0 \
       --hints:off \
+      $COMPILER \
       --out:"$output/executable" \
       --nimcache:"$output/" \
       "$1"

--- a/nimrun
+++ b/nimrun
@@ -36,7 +36,8 @@ compiler_exit=$?
 shift
 
 if [ "$compiler_exit" -eq 0 ]; then  # compile success
-  $output/executable $*
+  # "$@" is necessary to preserve whitespaces in arguments, which $* doesn't
+  $output/executable "$@"
   exit $?
 else  # compile fail
   exit $compiler_exit


### PR DESCRIPTION
- Arguments like `"foo bar"` failed and were split into two arguments instead
- Compile times for Hello World: GCC: 1.3 s, Clang: 0.8 s, TCC: 0.5 s
