### PR TITLE
Fix mktemp call to support OS X.

### DIFF
--- a/nimrun
+++ b/nimrun
@@ -27,7 +27,7 @@ elif command -v clang >/dev/null 2>&1; then
   COMPILER=--cc:clang
 fi
 
-output=$(mktemp -d)
+output=$(mktemp -d -t ${1}.XXXX)
 trap "rm -rf $output" EXIT
 
 nim c --verbosity:0 \


### PR DESCRIPTION
Hi there,

Playing around with your nimrun script I found that the mktemp call doesn't work correctly on OS X.  I've updated the script slightly to allow for it to work properly.
